### PR TITLE
Local thumbnail support

### DIFF
--- a/MyAnimePlugin3/Windows/MainWindow.cs
+++ b/MyAnimePlugin3/Windows/MainWindow.cs
@@ -4102,27 +4102,30 @@ namespace MyAnimePlugin3
 
       foreach (JMMServerBinary.Contract_VideoDetailed epcontract in epContracts)
       {
-        string EpisodeFilePath = epcontract.VideoLocal_FilePath;
-        int ImportFolderID = epcontract.ImportFolderID;
-        string FullPath = Path.Combine(BaseConfig.Settings.ImportFolderMappings[ImportFolderID], EpisodeFilePath);
+        string episodeFilePath = epcontract.VideoLocal_FilePath;
+        int importFolderId = epcontract.ImportFolderID;
 
         //BaseConfig.MyAnimeLog.Write("FILE PATH: " + episodeFilePath);
         //BaseConfig.MyAnimeLog.Write("IMPORT FOLDER ID: " + ImportFolderID.ToString());
-        //BaseConfig.MyAnimeLog.Write("FULL PATH: " + fullPath);
 
-        string EpisodeFileNameWithoutExtension = Path.GetFileNameWithoutExtension(FullPath);
-        string EpisodeFilePathWithoutExtension = Path.Combine(Path.GetDirectoryName(FullPath), EpisodeFileNameWithoutExtension);
+
+        // Full episode file path with file extension
+        string episodeFilePathWithExtension = Path.Combine(BaseConfig.Settings.ImportFolderMappings[importFolderId], episodeFilePath);
+
+        // Full episode file path without file extension
+        string episodeFileNameWithoutExtension = Path.GetFileNameWithoutExtension(episodeFilePathWithExtension);
+        string episodeFilePathWithoutExtension = Path.Combine(Path.GetDirectoryName(episodeFilePathWithExtension), episodeFileNameWithoutExtension);
 
         // Thumbnail format: <episode_full_path_without_extension>.jpg <--- the Mediaportal default
-        if (File.Exists(EpisodeFilePathWithoutExtension + ".jpg"))
+        if (File.Exists(episodeFilePathWithoutExtension + ".jpg"))
         {
-          Thumbnail = EpisodeFilePathWithoutExtension + ".jpg";
+          Thumbnail = episodeFilePathWithoutExtension + ".jpg";
           return Thumbnail;
         }
         // Thumbnail format: <episode_full_path_with_extension>.jpg <--- the standard in programs like Video Thumbnails Maker
-        else if (File.Exists(FullPath + ".jpg"))
+        else if (File.Exists(episodeFilePathWithExtension + ".jpg"))
         {
-          Thumbnail = FullPath + ".jpg";
+          Thumbnail = episodeFilePathWithExtension + ".jpg";
           return Thumbnail;
         }
       }

--- a/MyAnimePlugin3/Windows/MainWindow.cs
+++ b/MyAnimePlugin3/Windows/MainWindow.cs
@@ -4091,34 +4091,36 @@ namespace MyAnimePlugin3
 
     public string LoadLocalThumbnail(int episodeID)
     {
-      string fileName = "";
+      string Thumbnail = "";
 
       List<JMMServerBinary.Contract_VideoDetailed> epContracts = JMMServerVM.Instance.clientBinaryHTTP.GetFilesForEpisode(episodeID, JMMServerVM.Instance.CurrentUser.JMMUserID);
 
       foreach (JMMServerBinary.Contract_VideoDetailed epcontract in epContracts)
       {
-        string episodeFilePath = epcontract.VideoLocal_FilePath;
+        string EpisodeFilePath = epcontract.VideoLocal_FilePath;
         int ImportFolderID = epcontract.ImportFolderID;
-        string fullPath = Path.Combine(BaseConfig.Settings.ImportFolderMappings[ImportFolderID], episodeFilePath);
+        string FullPath = Path.Combine(BaseConfig.Settings.ImportFolderMappings[ImportFolderID], EpisodeFilePath);
 
         //BaseConfig.MyAnimeLog.Write("FILE PATH: " + episodeFilePath);
         //BaseConfig.MyAnimeLog.Write("IMPORT FOLDER ID: " + ImportFolderID.ToString());
         //BaseConfig.MyAnimeLog.Write("FULL PATH: " + fullPath);
 
-        string episodeFilePathWithoutExtension = Path.GetFileNameWithoutExtension(fullPath);
+        string EpisodeFilePathWithoutExtension = Path.GetFileNameWithoutExtension(FullPath);
 
-        if (File.Exists(episodeFilePathWithoutExtension + ".jpg"))
+        // thumbnail format: <episode_full_path_without_extension>.jpg <--- the Mediaportal default
+        if (File.Exists(EpisodeFilePathWithoutExtension + ".jpg"))
         {
-          fileName = episodeFilePathWithoutExtension + ".jpg";
-          return fileName;
+          Thumbnail = EpisodeFilePathWithoutExtension + ".jpg";
+          return Thumbnail;
         }
-        else if (File.Exists(fullPath + ".jpg"))
+        // thumbnail format: <episode_full_path_with_extension>.jpg <--- the standard in programs like Video Thumbnails maker
+        else if (File.Exists(FullPath + ".jpg"))
         {
-          fileName = fullPath + ".jpg";
-          return fileName;
+          Thumbnail = FullPath + ".jpg";
+          return Thumbnail;
         }
       }
-      return "";
+      return Thumbnail;
     }
 
 

--- a/MyAnimePlugin3/Windows/MainWindow.cs
+++ b/MyAnimePlugin3/Windows/MainWindow.cs
@@ -4105,15 +4105,16 @@ namespace MyAnimePlugin3
         //BaseConfig.MyAnimeLog.Write("IMPORT FOLDER ID: " + ImportFolderID.ToString());
         //BaseConfig.MyAnimeLog.Write("FULL PATH: " + fullPath);
 
-        string EpisodeFilePathWithoutExtension = Path.GetFileNameWithoutExtension(FullPath);
+        string EpisodeFileNameWithoutExtension = Path.GetFileNameWithoutExtension(FullPath);
+        string EpisodeFilePathWithoutExtension = Path.Combine(Path.GetDirectoryName(FullPath), EpisodeFileNameWithoutExtension);
 
-        // thumbnail format: <episode_full_path_without_extension>.jpg <--- the Mediaportal default
+        // Thumbnail format: <episode_full_path_without_extension>.jpg <--- the Mediaportal default
         if (File.Exists(EpisodeFilePathWithoutExtension + ".jpg"))
         {
           Thumbnail = EpisodeFilePathWithoutExtension + ".jpg";
           return Thumbnail;
         }
-        // thumbnail format: <episode_full_path_with_extension>.jpg <--- the standard in programs like Video Thumbnails maker
+        // Thumbnail format: <episode_full_path_with_extension>.jpg <--- the standard in programs like Video Thumbnails Maker
         else if (File.Exists(FullPath + ".jpg"))
         {
           Thumbnail = FullPath + ".jpg";

--- a/MyAnimePlugin3/Windows/MainWindow.cs
+++ b/MyAnimePlugin3/Windows/MainWindow.cs
@@ -3891,7 +3891,8 @@ namespace MyAnimePlugin3
       {
         setGUIProperty("Episode.Image", curAnimeEpisode.EpisodeImageLocation);
 
-        // Try to find local thumbnail and use that instead of Fanart (optional)
+        // Try to find local thumbnail and use that instead of Fanart (optional - disabled by default)
+        /*
         string localThumbnail = LoadLocalThumbnail(curAnimeEpisode.AnimeEpisodeID);
         if (!string.IsNullOrEmpty(localThumbnail))
         {
@@ -3899,7 +3900,7 @@ namespace MyAnimePlugin3
 
           if (this.dummyIsFanartLoaded != null)
             this.dummyIsFanartLoaded.Visible = true;
-        }
+        }*/
       }
       else
       {
@@ -4131,8 +4132,6 @@ namespace MyAnimePlugin3
       }
       return Thumbnail;
     }
-
-
 
 		void DisableFanart()
 		{


### PR DESCRIPTION
This adds local thumbnail support to MA3, there are currently 2 supported formats:

episode_full_path_without_extension.jpg <--- the Mediaportal default
episode_full_path_with_extension.jpg <--- the standard in programs like Video Thumbnails Maker
 
It will use the first video file linked for the thumbnail and if it has none otherwise skips to next as there's no knowing if the other video thumbnails would be any better.

Optionally I have it replace the current Fanart for each episode in the episode overview if a thumbnail exists which creates a large overlay at the top instead of the normal fanart, this now only applies if it has no remote thumbnail available.